### PR TITLE
Add MEMORY_MODEL to checkin test suite

### DIFF
--- a/.jenkins/debug.groovy
+++ b/.jenkins/debug.groovy
@@ -40,7 +40,7 @@ def runCI =
     {
         platform, project->
 
-        def gfilter = '*checkin_lapack*'
+        def gfilter = 'checkin*'
         commonGroovy.runTestCommand(platform, project, gfilter)
     }
 

--- a/.jenkins/extended.groovy
+++ b/.jenkins/extended.groovy
@@ -40,7 +40,7 @@ def runCI =
     {
         platform, project->
 
-        def gfilter = '*daily_lapack*'
+        def gfilter = 'daily*'
         commonGroovy.runTestCommand(platform, project, gfilter)
     }
 

--- a/.jenkins/precheckin.groovy
+++ b/.jenkins/precheckin.groovy
@@ -38,7 +38,7 @@ def runCI =
     {
         platform, project->
 
-        def gfilter = '*checkin_lapack*'
+        def gfilter = 'checkin*'
         commonGroovy.runTestCommand(platform, project, gfilter)
     }
 

--- a/.jenkins/staticlibrary.groovy
+++ b/.jenkins/staticlibrary.groovy
@@ -40,7 +40,7 @@ def runCI =
     {
         platform, project->
 
-        def gfilter = '*checkin_lapack*'
+        def gfilter = 'checkin*'
         commonGroovy.runTestCommand(platform, project, gfilter)
     }
 

--- a/clients/gtest/memory_model_gtest.cpp
+++ b/clients/gtest/memory_model_gtest.cpp
@@ -27,7 +27,7 @@ static bool unset_environment_variable(const char* name)
 #endif
 }
 
-class MEMORY_MODEL : public ::testing::Test
+class checkin_misc_MEMORY_MODEL : public ::testing::Test
 {
 protected:
     void SetUp() override
@@ -68,7 +68,7 @@ protected:
 /*************************************/
 /***** rocblas_managed (default) *****/
 /*************************************/
-TEST_F(MEMORY_MODEL, rocblas_managed)
+TEST_F(checkin_misc_MEMORY_MODEL, rocblas_managed)
 {
     size_t size, size1;
     rocblas_status status;
@@ -139,7 +139,7 @@ TEST_F(MEMORY_MODEL, rocblas_managed)
     EXPECT_EQ(rocblas_destroy_handle(handle), rocblas_status_success);
 }
 
-TEST_F(MEMORY_MODEL, user_managed)
+TEST_F(checkin_misc_MEMORY_MODEL, user_managed)
 {
     size_t size;
     rocblas_status status;
@@ -273,7 +273,7 @@ TEST_F(MEMORY_MODEL, user_managed)
 /*************************************/
 /******** user owned workspace *******/
 /*************************************/
-TEST_F(MEMORY_MODEL, user_owned)
+TEST_F(checkin_misc_MEMORY_MODEL, user_owned)
 {
     size_t size;
     rocblas_status status;

--- a/rtest.xml
+++ b/rtest.xml
@@ -2,10 +2,10 @@
 <testset>
     <var name="COMMAND">rocsolver-test --gtest_color=yes </var>
     <test sets="psdb">
-        <run name="all-psdb">{COMMAND} --gtest_filter=*checkin_lapack*-*known_bug* --gtest_output=xml </run>
+        <run name="all-psdb">{COMMAND} --gtest_filter=checkin*-*known_bug* --gtest_output=xml </run>
     </test>
     <test sets="osdb">
-        <run name="all-osdb">{COMMAND} --gtest_filter=*daily_lapack*-*known_bug* --gtest_output=xml </run>
+        <run name="all-osdb">{COMMAND} --gtest_filter=daily*-*known_bug* --gtest_output=xml </run>
     </test>
     <test sets="hmm">
         <!-- * These tests should only be run on devices supporting HMM -->


### PR DESCRIPTION
- Change MEMORY_MODEL test name to start with checkin.
- Change gtest filter to `checkin` and `daily` prefixes for psdb and osdb, respectively.