### PR TITLE
Clear `tempgemm` to prevent erros due to multiplication with spurious NaNs

### DIFF
--- a/library/src/auxiliary/rocauxiliary_stedc.cpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.cpp
@@ -94,6 +94,13 @@ rocblas_status rocsolver_stedc_impl(rocblas_handle handle,
     splits_map = mem[4];
     workArr = mem[5];
 
+    if (size_tempgemm > 0)
+    {
+        hipStream_t stream;
+        rocblas_get_stream(handle, &stream);
+        HIP_CHECK(hipMemsetAsync((void *)tempgemm, 0, size_tempgemm, stream));
+    }
+
     // execution
     return rocsolver_stedc_template<false, false, T>(
         handle, evect, n, D, shiftD, strideD, E, shiftE, strideE, C, shiftC, ldc, strideC, info,

--- a/library/src/auxiliary/rocauxiliary_stedc.cpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.cpp
@@ -94,11 +94,11 @@ rocblas_status rocsolver_stedc_impl(rocblas_handle handle,
     splits_map = mem[4];
     workArr = mem[5];
 
-    if (size_tempgemm > 0)
+    if(size_tempgemm > 0)
     {
         hipStream_t stream;
         rocblas_get_stream(handle, &stream);
-        HIP_CHECK(hipMemsetAsync((void *)tempgemm, 0, size_tempgemm, stream));
+        HIP_CHECK(hipMemsetAsync((void*)tempgemm, 0, size_tempgemm, stream));
     }
 
     // execution


### PR DESCRIPTION
`tempgemm` must be free of spurious `NaN`s when `stedc` is set to use external `gemm`s, as the eigenvectors may get corrupted otherwise.